### PR TITLE
Use correct variable when setting the RDS instance type as part of AS…

### DIFF
--- a/roles/aws/aws_ec2_autoscale_cluster/tasks/main.yml
+++ b/roles/aws/aws_ec2_autoscale_cluster/tasks/main.yml
@@ -95,7 +95,7 @@
     aws_rds:
       aws_profile: "{{ aws_ec2_autoscale_cluster.aws_profile }}"
       region: "{{ aws_ec2_autoscale_cluster.region }}"
-      instance_type: "{{ aws_ec2_autoscale_cluster.rds.db_instance_class }}"
+      db_instance_class: "{{ aws_ec2_autoscale_cluster.rds.db_instance_class }}"
       subnets: "{{ _aws_ec2_autoscale_cluster_subnets_ids }}"
       name: "{{ aws_ec2_autoscale_cluster.name }}"
       description: "{{ aws_ec2_autoscale_cluster.name }}"


### PR DESCRIPTION
…G creation.