### PR TITLE
Nginx: allow install|update scripts in Drupal8+

### DIFF
--- a/roles/nginx/templates/drupal8.j2
+++ b/roles/nginx/templates/drupal8.j2
@@ -1,7 +1,11 @@
 ######### Default block.
 
 # Generic rewrite rule.
-    location @rewrite {
+location @rewrite {
     rewrite ^ /index.php?$query_string;
+}
+# Allow install/update for local stack for Drupal8+.
+location ~ ^/core/(install|update).php$ {
+    try_files @phpprocess @phpprocess;
 }
 include "/etc/nginx/conf.d/drupal_common";


### PR DESCRIPTION
The install|update scripts are /core/install.php and /core/update.php.
Current nginx templates have only configured the D7 version (/install|update.php). It means if a client tries to use the update.php script or the install.php it doesn't work.