### PR TITLE
Turn off HTTP auth in Nginx vhosts when certbot is used

### DIFF
--- a/.github/workflows/ce-provision-lint.yml
+++ b/.github/workflows/ce-provision-lint.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y python3-pip yamllint shellcheck
-          pip3 install ansible-base ansible-lint
+          pip3 install ansible ansible-lint
           find ./roles -name "*.yml"  | xargs ansible-lint
           yamllint ./roles
           cd scripts && shellcheck *.sh

--- a/roles/nginx/templates/vhosts.j2
+++ b/roles/nginx/templates/vhosts.j2
@@ -33,6 +33,7 @@ server {
 {% if domain.ssl.web_server | default('none') == 'none' %}
     # Proxy for certbot (LetsEncrypt)
     location /.well-known/acme-challenge/ {
+        auth_basic off;
         proxy_pass http://127.0.0.1:{{ domain.ssl.http_01_port }}$request_uri;
     }
 {% endif %}


### PR DESCRIPTION
And fix linting in the GitHub Actions workflow.