### PR TITLE
We must not merge www.example.com with ssl.domain

### DIFF
--- a/roles/ssl/tasks/main.yml
+++ b/roles/ssl/tasks/main.yml
@@ -9,7 +9,7 @@
 
 - name: Catch legacy implementations with ssl.domain set. # @todo: this can be removed in a later release
   ansible.builtin.set_fact:
-    _ssl_domains: "{{ _ssl_domains + [ ssl.domain ] }}"
+    _ssl_domains: "{{ [ ssl.domain ] }}"
   when: ssl.domain is defined
 
 - name: Generates SSL keys.


### PR DESCRIPTION
There's only one domain with legacy implementations.