### PR TITLE
Force install of latest CloudWatch Agent regardless of current version.

### DIFF
--- a/roles/aws_cloudwatch_agent/tasks/main.yml
+++ b/roles/aws_cloudwatch_agent/tasks/main.yml
@@ -2,6 +2,7 @@
 - name: Install deb for AWS CloudWatch agent.
   ansible.builtin.apt:
     deb: "https://s3.amazonaws.com/amazoncloudwatch-agent/debian/amd64/latest/amazon-cloudwatch-agent.deb"
+    force: true
     state: present
 
 - name: Adds cwagent user to adm group for log access.


### PR DESCRIPTION
WIP pending testing.