### PR TITLE
Accelerate asg deregistration pr devel (#760)

### DIFF
--- a/roles/aws/aws_ec2_autoscale_cluster/defaults/main.yml
+++ b/roles/aws/aws_ec2_autoscale_cluster/defaults/main.yml
@@ -101,6 +101,7 @@ aws_ec2_autoscale_cluster:
   alb_health_check_type: ELB # Uses ALB health checks, set to EC2 to use default AWS instance status checks
   alb_health_check_period: 1200 # Length of time in seconds after a new EC2 instance comes into service that Auto Scaling starts checking its health
   # Target Group health checks - these are distinct and separate checks carried out by the Target Group for the ASG
+  deregistration_delay_timeout_seconds: 60 # seconds to wait before removing instance from Target Group
   health_check_protocol: "http"
   health_check_path: "/"
   health_check_port: "traffic-port" # Default is traffic-port, which matches the target port. Can be overridden with a port number.

--- a/roles/aws/aws_ec2_autoscale_cluster/defaults/main.yml
+++ b/roles/aws/aws_ec2_autoscale_cluster/defaults/main.yml
@@ -101,7 +101,7 @@ aws_ec2_autoscale_cluster:
   alb_health_check_type: ELB # Uses ALB health checks, set to EC2 to use default AWS instance status checks
   alb_health_check_period: 1200 # Length of time in seconds after a new EC2 instance comes into service that Auto Scaling starts checking its health
   # Target Group health checks - these are distinct and separate checks carried out by the Target Group for the ASG
-  deregistration_delay_timeout_seconds: 60 # seconds to wait before removing instance from Target Group
+  deregistration_delay_timeout: 60 # seconds to wait before removing instance from Target Group
   health_check_protocol: "http"
   health_check_path: "/"
   health_check_port: "traffic-port" # Default is traffic-port, which matches the target port. Can be overridden with a port number.

--- a/roles/aws/aws_ec2_autoscale_cluster/tasks/main.yml
+++ b/roles/aws/aws_ec2_autoscale_cluster/tasks/main.yml
@@ -239,7 +239,7 @@
     protocol: http
     port: 80
     vpc_id: "{{ _aws_ec2_autoscale_cluster_vpc_id }}"
-    deregistration_delay_timeout_seconds: "{{ aws_ec2_autoscale_cluster.deregistration_delay_timeout_seconds }}"
+    deregistration_delay_timeout: "{{ aws_ec2_autoscale_cluster.deregistration_delay_timeout }}"
     health_check_protocol: "{{ aws_ec2_autoscale_cluster.health_check_protocol }}"
     health_check_path: "{{ aws_ec2_autoscale_cluster.health_check_path }}"
     health_check_port: "{{ aws_ec2_autoscale_cluster.health_check_port }}"

--- a/roles/aws/aws_ec2_autoscale_cluster/tasks/main.yml
+++ b/roles/aws/aws_ec2_autoscale_cluster/tasks/main.yml
@@ -239,6 +239,7 @@
     protocol: http
     port: 80
     vpc_id: "{{ _aws_ec2_autoscale_cluster_vpc_id }}"
+    deregistration_delay_timeout_seconds: "{{ aws_ec2_autoscale_cluster.deregistration_delay_timeout_seconds }}"
     health_check_protocol: "{{ aws_ec2_autoscale_cluster.health_check_protocol }}"
     health_check_path: "{{ aws_ec2_autoscale_cluster.health_check_path }}"
     health_check_port: "{{ aws_ec2_autoscale_cluster.health_check_port }}"


### PR DESCRIPTION
* GitHub Actions - Rebuilt documentation.

* Need to check if is_local is defined in webserver meta dependencies. (#522)

* Ce dev refactor pr 1.x (#518)

* Making it easier to test with provision-target and ce-dev.

* Moving the provision forcing var back to plays so _init has it.

* Adding defaults vars and test script extra options.

* Adding a web server test to CI.

* examples string needs to be in quotes.

* Making sure is_local and _ce_provision_force_play are available to the _init role.

* Adding SSH keys to the provision user.

* Adding a --force to the test script.

* Explicitly adding vars to role.

* Fixing _init behaviour and adding SSH key for web role.

* Setting default PHP version to 7.4.

* Looking up the generated ce-dev SSH key instead of hard-coding one.

* We cannot run the ssh_server role locally, so excluding for tests of webserver role.

* Trying to remove user_root.yml in case it's breaking CI.

* Adding a verbose mode to the test script.

* Exposing the command in the test script.

* Trying hard-coded keys again.

* Changing location of data dir for test containers.

* Putting vars back and restricting CI to the 'web' example.

* Adding backup handling to ldap_server. (#525)

* Adding backup handling to ldap_server.

* Improving SSL docs and handling perms for openldap and letsencrypt.

* Cron user must be specified with file.

* Running as root, do not need a 'sudo' in this cron.

* Allowing 'gitLab' to disable Prometheus. (#530)

* Allowing 'gitLab' to disable Prometheus.

* Booleans to use in jinja2 as strings must be cast as strings.

* GitHub Actions - Rebuilt documentation. (#526)

Co-authored-by: Code Enigma CI <sysadm@codeenigma.com>

* Prometheus pr 1.x (#533)

* Allowing 'gitLab' to disable Prometheus.

* Booleans to use in jinja2 as strings must be cast as strings.

* Tidying up CI and adding a GitLab test.

* Fixing CI job description.

* Add private files support for Drupal in Nginx. (#535)

* Prometheus pr 1.x (#539)

* Allowing 'gitLab' to disable Prometheus.

* Booleans to use in jinja2 as strings must be cast as strings.

* Tidying up CI and adding a GitLab test.

* Fixing CI job description.

* Adding a firewall config preset to open port 80 for LetsEncrypt.

* Removing our unused ClamAV roles and adding a Galaxy role to common base. (#541)

* Revert "Moving OSSEC pkill to use process_manager role instead. (#258)" (#544)

This reverts commit 73c7bd0adb1105436e484fe794182c915b2d25dd.

* Backing out of Packer logging.

* Moving key servers to a variable so we can set them. (#555)

* Moving key servers to a variable so we can set them.

* Allowing us to disable sending keys completely.

* Oops, doubled up on existing functionality.

* Fixing var name.

* Adding a reboot option to the patching role. (#557)

* Add minimal support for Aurora RDS instances (#567)

* Attempt to create an RDS read replica.

* Use new task to create Aurora RDS instances.

* Try and fix linting issues.

* Don't pass max_storage variable for Aurora instances.

* Remove more storage related vars from Aurora RDS instance creation task.

* Add profile and region to read replica creation.

* Try creating the Aurora read replica another way.

* Add some debug info.

* Work around the silly registering of variables in Ansible.

* Rename an RDS CloudWatch task for Aurora DBs and remove RDS debug info.

* Add some Aurora info to aws_rds README file.

* Use reader instead of replica for Aurora readers.

* Remove db_cluster_identifier variable from non-Aurora RDS task.

* Gpg servers fix pr 1.x (#571)

* Moving key servers to a variable so we can set them.

* Allowing us to disable sending keys completely.

* Oops, doubled up on existing functionality.

* Fixing var name.

* Using a pipe to grep with 'command' cannot work, refactoring.

* Making CI use the meta deploy role to test gitlab.

* We mustn't assume AWS servers for deploy and controller.

* Support termination protection in EC2. (#573)

* Support termination protection in EC2.

* Fixing CI vars.

* Fixing CI vars.

* Fix managed SSL key perms and the variable used for the private key. (#575)

* Ec2 subnet lookup pr 1.x (#583)

* First pass at EC2 subnet detection.

* Touching subnet file to ensure it exists.

* Trying a different approach, file module didn't work.

* Switching back to file module.

* We need to create the directory for new servers too.

* Bad variable name.

* Ec2 subnet lookup pr 1.x (#589)

* First pass at EC2 subnet detection.

* Touching subnet file to ensure it exists.

* Trying a different approach, file module didn't work.

* Switching back to file module.

* We need to create the directory for new servers too.

* Bad variable name.

* Changing subnet lookup order to check for defined subnet first.

* Fixing gitlab-runner overriders so upgrades do not break the runner. (#586)

* Fixing gitlab-runner overriders so upgrades do not break the runner.

* Fixing override file template.

* Hopefully fixing CI.

* Making sure the service directory exists.

* We cannot use the deploy meta role in CI because of LDAP.

* Changing dir perms and adding a force.

* Gitlab runner service override pr 1.x (#591)

* Fixing gitlab-runner overriders so upgrades do not break the runner.

* Fixing override file template.

* Hopefully fixing CI.

* Making sure the service directory exists.

* We cannot use the deploy meta role in CI because of LDAP.

* Changing dir perms and adding a force.

* Debugging gitlab-runner directory creation issues in CI.

* Fixing linting error.

* Removing verbosity again but leaving 'stat' command in.

* Pass db_cluster_identifier for RDS instance during ASG build (#600)

* Pass RDS db_cluster_identifier, if present, during an ASG build.

* Use correct variable name for RDS db_cluster_identifier.

* Add a commented variable to ASG role for db_cluster_identifier so it's documented.

* Also pass in the aurora_reader var from the ASG role when including the aws_rds role. (#605)

* Removing obsolete MySQL config option log_syslog from template. (#607)

* GitHub Actions - Rebuilt documentation. (#536)

Co-authored-by: Code Enigma CI <sysadm@codeenigma.com>

* Consistent default region pr 1.x (#611)

* Moving all region settings to _aws_region var and adding README update.

* Documentation update.

* No need for region, IAM SAML setup is global, (#617)

* Support ebs encryption pr 1.x (#609)

* Adding volume encryption and type options plus a bit more flexibility on EBS control for EC2.

* Setting more sane default instance sizes.

* Adding more EBS options for ASGs.

* Setting encryption to match AMI settings.

* Setting encryption to match AMI settings.

* We also need to dynamically set the ASGs own encrypt_boot var.

* We need to merge the new branch changes before we can rebuild the docs.

* Fixing merge command in CI.

* Not sure toc.sh is actually executing.

* Refactoring encrypt EBS flags to avoid detected loop condition in vars.

* Safer CI, only adds .md files.

* Trying to figure out CI logic for building docs.

* Trying to figure out CI logic for building docs.

* Trying to figure out CI logic for building docs.

* Trying adding a git pull.

* Setting git pull config options.

* Reordering things.

* Adding --allow-unrelated-histories to the git pull.

* Trying a feature branch approach.

* Forcing the GitHub action to fetch all git history.

* Bad whitespace, naughty whitespace.

* Trying a different PR action.

* Do not merge the branch in, we only want the markdown changes.

* Keeping the documentation branch clean.

* We need to push a detached HEAD.

* Do we need the checkout at all?

* Adding a docs pull.

* Allow install|update scripts in Drupal8+ (#599)

* Add some flexibility to Packer (#633)

* Add ability to pass on-error and force to Packer.

* Add new Packer options to the ASG role as well.

* Packer build options need to be declared before the file that is being built.

* Allow Packer ssh_username to be set.

* Making PHP >= 8.0 compatible (#634)

* Packer VPC filtering (#638)

* Add ability to set vpc_filter and subnet AZ for Packer builds.

* Add fqcn-builtins to .ansible-lint warn_list for now.

* GitHub Actions seemingly ignores warn_list.

* Use simplified variables for Packer VPC stuff.

* Only use one filter when filtering VPCs for Packer.

* Cert management pr 1.x (#640)

* Making sure we can't accidentally commit AWS API credentials.

* Initial commit of ACM role.

* Only pause for a get-certificate call if we want to export.

* Updating docs.

* Cert management pr 1.x (#642)

* Making sure we can't accidentally commit AWS API credentials.

* Initial commit of ACM role.

* Only pause for a get-certificate call if we want to export.

* Updating docs.

* Missed a couple of variables to update.

* Cert management pr 1.x (#644)

* Making sure we can't accidentally commit AWS API credentials.

* Initial commit of ACM role.

* Only pause for a get-certificate call if we want to export.

* Updating docs.

* Missed a couple of variables to update.

* We cannot rely on the variable being nonexistent here.

* Cert management pr 1.x (#647)

* Making sure we can't accidentally commit AWS API credentials.

* Initial commit of ACM role.

* Only pause for a get-certificate call if we want to export.

* Updating docs.

* Missed a couple of variables to update.

* We cannot rely on the variable being nonexistent here.

* Allowing ce-provision to set the basic auth message for Nginx.

* Supporting SAN certs and tags on ACM certificates.

* Fixing namespacing.

* Auto-generating SSL certs for ALB and CloudFront.

* More namespace fixes.

* Fixing CI issue with missing AWS region var.

* Reinstating replace_batch_size for ASGs to see if it speeds up infra builds.

* Adding public IP option to LC config for ASGs.

* Refactoring ACM domain handling so we can create DNS entries for each SAN domain.

* Fixing mistake in domains set_fact.

* Fixing AnsibleUndefined bug caused by skipped task.

* Fix Nginx auth_message in vhost (#653)

* Revert auth_message change in Nginx role for now.

* Revert "Revert auth_message change in Nginx role for now."

This reverts commit d030e4c628728ab553a0f5687497cf566bcd1179.

* Add default for Nginx auth_message.

* Cert management pr 1.x (#655)

* Making sure we can't accidentally commit AWS API credentials.

* Initial commit of ACM role.

* Only pause for a get-certificate call if we want to export.

* Updating docs.

* Missed a couple of variables to update.

* We cannot rely on the variable being nonexistent here.

* Allowing ce-provision to set the basic auth message for Nginx.

* Supporting SAN certs and tags on ACM certificates.

* Fixing namespacing.

* Auto-generating SSL certs for ALB and CloudFront.

* More namespace fixes.

* Fixing CI issue with missing AWS region var.

* Reinstating replace_batch_size for ASGs to see if it speeds up infra builds.

* Adding public IP option to LC config for ASGs.

* Refactoring ACM domain handling so we can create DNS entries for each SAN domain.

* Fixing mistake in domains set_fact.

* Fixing AnsibleUndefined bug caused by skipped task.

* Handling multiple domain validations for SAN certs.

* Fixing bad variable name.

* Fixing ASG DNS entries so it adds entries for SAN cert domains too.

* For DNS validation we should not use --domain-validation-options at all.

* Writing over the aws_acm.extra_domains var didn't work, setting a new var instead.

* Bad dict structure.

* Improving multi domain handling for ASG DNS.

* Supporting multiple CloudFront aliases for an ASG.

* Adding options to disable sign-up, sign-in and private projects. (#663)

* Making ALB healthchecks optional and defaulting to disabled. (#670)

* Making ALB healthchecks optional and defaulting to disabled.

* Defaulting back to ELB health checks.

* Remove alb healthchecks pr 1.x (#673)

* Making ALB healthchecks optional and defaulting to disabled.

* Defaulting back to ELB health checks.

* Making sure new clusters won't fail because no ALB yet.

* Allow user to set cachetool version in the opcache role. (#665)

* Allow user to set cachetool version in the opcache role.

* Adding a comment for a future improvement.

* Adding a 'repack' option for AMIs and ASGs. (#675)

* Adding a 'repack' option for AMIs and ASGs.

* Adding an option to force a Packer rebuild in an ASG.

* Fixing EC2 instance look-up to use cluster name.

* Separating AMI provisioning tasks into a tasks file that can be included.

* Refactoring AMI operation to allow current behaviour to remain default.

* Trying to delegate tasks to target repack instance.

* Switching from import_tasks to include_tasks.

* Fixing the instance DNS name var.

* Changing approach to make a standalone machine to generate AMI from.

* Gah! Typo!

* AMI generation requires region and profile.

* Didn't wrap instance_id lookup properly.

* Fixing some missing namespaces.

* Missed a bad var when fixing.

* Adding full set of variables for EC2 instance.

* Fixing AWS SSH key name.

* Decided not to use the EC2 + EIP role.

* Trying to add a pause after instance launch.

* Passing the target branch to Ansible as a var.

* Support absolute paths to playbooks.

* Refactoring to make ce-provision call itself for AMI packing tasks.

* Doubled up the script path.

* Switching to base dir var for ce-provision call.

* Moving temp EC2 instances for AMI creation to subnet with IGW.

* State of EC2 instance needs to be started instead of running.

* We need to delete the AMI we created before making another one.

* Refactoring AMI repack variables for readability and removing volume size.

* Missed a refactored var.

* Defending against AMI volume size issues for ASGs.

* Refactoring extra vars handling.

* For some reason Packer seems to double the brackets.

* Revert "For some reason Packer seems to double the brackets."

This reverts commit 13ee8df42b80b102e9e19a01407b3afb69952ee5.

* Fixing packer.json white space.

* We need to reset the _aws_ami_extra_vars variable to an empty string before we rebuild it.

* Slight refactor to move the extra vars building to the relevant included tasks.

* Slight documentation change.

* Moved config extra vars to ce-provision as they are globally sane.

* Error in jinja list building for RDS.

* Ami repack option pr 1.x (#707)

* Adding a 'repack' option for AMIs and ASGs.

* Adding an option to force a Packer rebuild in an ASG.

* Fixing EC2 instance look-up to use cluster name.

* Separating AMI provisioning tasks into a tasks file that can be included.

* Refactoring AMI operation to allow current behaviour to remain default.

* Trying to delegate tasks to target repack instance.

* Switching from import_tasks to include_tasks.

* Fixing the instance DNS name var.

* Changing approach to make a standalone machine to generate AMI from.

* Gah! Typo!

* AMI generation requires region and profile.

* Didn't wrap instance_id lookup properly.

* Fixing some missing namespaces.

* Missed a bad var when fixing.

* Adding full set of variables for EC2 instance.

* Fixing AWS SSH key name.

* Decided not to use the EC2 + EIP role.

* Trying to add a pause after instance launch.

* Passing the target branch to Ansible as a var.

* Support absolute paths to playbooks.

* Refactoring to make ce-provision call itself for AMI packing tasks.

* Doubled up the script path.

* Switching to base dir var for ce-provision call.

* Moving temp EC2 instances for AMI creation to subnet with IGW.

* State of EC2 instance needs to be started instead of running.

* We need to delete the AMI we created before making another one.

* Refactoring AMI repack variables for readability and removing volume size.

* Missed a refactored var.

* Defending against AMI volume size issues for ASGs.

* Refactoring extra vars handling.

* For some reason Packer seems to double the brackets.

* Revert "For some reason Packer seems to double the brackets."

This reverts commit 13ee8df42b80b102e9e19a01407b3afb69952ee5.

* Fixing packer.json white space.

* We need to reset the _aws_ami_extra_vars variable to an empty string before we rebuild it.

* Slight refactor to move the extra vars building to the relevant included tasks.

* Slight documentation change.

* Moved config extra vars to ce-provision as they are globally sane.

* Error in jinja list building for RDS.

* Trailing VPC ID fields using the wrong variable.

* Editing GitLab config so LE is enabled and auto-renewing by default. (#709)

* Provide profile and region when creating an RDS parameter group, and also provide ability to set the parameter group for an Aurora RDS instance. (#712)

* Add a task in ASG role to add an Aurora RDS endpoint. (#714)

* Ssl le fixes pr 1.x (#725)

* Allow multiple domains to be passed.

* Ensuring we don't break older implementations.

* First pass at a bash script we can run on cron for LE renewals.

* Place the autorenewal script and create a cron entry.

* Allowing the HTTP-01 listen port to be set to something other than 80.

* Need single quotes within our double quotes.

* Adding optional proxy for LE.

* Revert "Adding optional proxy for LE."

This reverts commit cf5720b450744915872eacafee82164300df90aa.

* Adding support for apache and nginx plugins for certbot.

* Fixing quote error.

* Fixing SSL LE handilng and ensuring other handlers work with multiple provided domains.

* Fixing issue with selecting first domain.

* Correcting variable names.

* LE cron template missing an endfor.

* Missing carriage return in LE cron script.

* Turns out you can't alter facts passed in via vars by include_role.

* Fixing SSL defaults.

* Realised if there are multiple different LE runs each needs it's own renewal cron.

* Ensure builds don't fail if ssl.web_server isn't provided.

* Defending against empty SSL services list.

* Improving vhost template LE handling.

* Adjusting SSL cert and key var names.

* Adding a temporary vhost so newly added domains can request LE certs.

* Tabbing error.

* Fixing possible 'resolver' errors in Nginx if you use localhost.

* Renaming loopvar from domain to certificate_domain to avoid clash with nginx role.

* Tweaking Nginx LE handling and making certbot commands customisable.

* Fixing minor typo.

* Trying giving include_role the public flag.

* Documentation updates.

* Adding default value to Nginx vhost template.

* Move drupal8 install/update config to drupal_common under if local block. (#733)

* WIP: 58848 apache role pr 1.x (#667)

* Catching up devel. (#243)

* Devel (#175)

* Wrong filter for efs info

* Fix indentation error

* Do not purge tags on existing EFS

* Wrong name for updating EFS targets

* Remove leftover loop

* Fix error in subnet gathering

* Split EFS creation

* Use subnet ids

* Wrong var name

* Remove dead code

* Wrong var

* Missing subnet ids

* Try not to loose existing SGs

* Try to dedupe targets

* Wrong syntax for combine

* Typo in combining tupples

* Wrong var name for append items

* Fix appending subnets

* Wrong list transformation

* Switch to community module for efs

* Remove unecessary complexity

* Update documentation

* Comment out Redefine Autoscale groups task for now and move some of its parameters to the other ASG creation task.

* Remove replace_batch_size from ASG creation task, so it now defaults to 1.

* Wrap Postfix handler commands in quotes. (#26)

* Try using shell instead of command in Postfix handlers.

* GitHub Actions integration (#29)

* Adding Super Linter workflow for GitHub Actions.

* Adding the documentation checker.

* Getting GitHub Actions to continue on failure.

* Seeing if Git exists.

* Missing space.

* Re-adding the checkout and the git commands.

* Trying Pascal's script.

* Adding both lines to the same 'run' command.

* GitHub Actions wtf - splitting into two steps.

* Trying steps on branch name.

* Trying steps on branch name AGAIN.

* Would be good to get the syntax right.

* Trying different quotes.

* Checking the contents of the github.ref variable.

* Trying to add in Pascal's testing step.

* Adding in /bin/sh to hopefully make test.sh run.

* Google says try it with /bin/bash.

* Trying a different Ubuntu version.

* Installing net-tools to have ifconfig.

* Updating testing shell (#28)

* Use correct variable when setting the RDS instance type as part of ASG creation. (#27)

* Fixing test.sh to explicitly call bash.

GitHub Actions only supports Ubuntu containers and Ubuntu shell is dash by default, not bash. Consequently /bin/sh doesn't invoke bash, but dash, which causes some unexpected errors down the line.

Co-authored-by: EmlynK <emlyn.kinzett@codeenigma.com>

* We probably don't need /bin/bash

* Making test.sh executable.

* Checking shell.

* Explicitly setting shell to bash in provision.sh.

* Trying ubuntu-16.04 as Travis used this.

* Putting shell back.

* Update provision.sh

* Making /bin/bash the shell.

* Making /bin/bash the shell for provision.

* Explicitly stating bash again in YML.

* Turns out the mkcert binary is out of date.

* Compiled mkcert from source.

* Fixing curl error.

* Switching to wget.

* Starting the linter again and renaming job.

* Only lint changed files.

* Linting a non-existent branch!

* Tidying the documentation check.

* Revert "Making /bin/bash the shell for provision."

This reverts commit f5f35818205cd364a66a6e51c9f9d8254f016422.

* Revert "Making /bin/bash the shell."

This reverts commit df585b36877aa2328adc228cd8f76950e2853d36.

* Revert "Tidying the documentation check."

This reverts commit a0c964e15003c8486f4d01232af6e855a475298e.

* Swapping Super-Linter for ansible-lint.

* Running ansible-lint directly in the container.

* Updating to latest Ubuntu.

* Revert "Fixing test.sh to explicitly call bash."

This reverts commit 521279ebc16a4c4459c981bfb813cf6aa4d4f3ad.

* Fixing ansible-lint issues.

* Revert "Fixing ansible-lint issues."

This reverts commit 08a74046d567ea80acc080ec3cec60a7f8ceed48.

* Removing old travis config.

* Spacing issue fix.

* Running tests on pull_request only.

Co-authored-by: EmlynK <emlyn.kinzett@codeenigma.com>

* Use correct variable when setting the RDS instance type as part of ASG creation. (#32)

Co-authored-by: Emlyn Kinzett <emlyn.kinzett@codeenigma.com>

* Fix alb health check (#31)

* It's traffic-port, not target-port. Doh.

* Update documentation.

Co-authored-by: Emlyn Kinzett <emlyn.kinzett@codeenigma.com>

* Adding note on existence of 'config' directory for de-deploy to work.

* Adding link to provided example config directory.

* Generate saml sso requirements (#33)

* Use correct variable when setting the RDS instance type as part of ASG creation. (#27)

* Adding AWS CLI and credentials files to local ce-dev.

* New AWS IAM Ansible role for creating the necessary IdP and role for admin access.

Co-authored-by: EmlynK <emlyn.kinzett@codeenigma.com>

* Generate saml sso requirements devel (#36)

* Use correct variable when setting the RDS instance type as part of ASG creation. (#27)

* Adding AWS CLI and credentials files to local ce-dev.

* New AWS IAM Ansible role for creating the necessary IdP and role for admin access.

* Cleaning variables to be generic and improving LDAP role handling.

Co-authored-by: EmlynK <emlyn.kinzett@codeenigma.com>

* Generate saml sso requirements devel (#37)

* Use correct variable when setting the RDS instance type as part of ASG creation. (#27)

* Adding AWS CLI and credentials files to local ce-dev.

* New AWS IAM Ansible role for creating the necessary IdP and role for admin access.

* GitHub actions into v1. (#30)

* Adding Super Linter workflow for GitHub Actions.

* Adding the documentation checker.

* Getting GitHub Actions to continue on failure.

* Seeing if Git exists.

* Missing space.

* Re-adding the checkout and the git commands.

* Trying Pascal's script.

* Adding both lines to the same 'run' command.

* GitHub Actions wtf - splitting into two steps.

* Trying steps on branch name.

* Trying steps on branch name AGAIN.

* Would be good to get the syntax right.

* Trying different quotes.

* Checking the contents of the github.ref variable.

* Trying to add in Pascal's testing step.

* Adding in /bin/sh to hopefully make test.sh run.

* Google says try it with /bin/bash.

* Trying a different Ubuntu version.

* Installing net-tools to have ifconfig.

* Updating testing shell (#28)

* Use correct variable when setting the RDS instance type as part of ASG creation. (#27)

* Fixing test.sh to explicitly call bash.

GitHub Actions only supports Ubuntu containers and Ubuntu shell is dash by default, not bash. Consequently /bin/sh doesn't invoke bash, but dash, which causes some unexpected errors down the line.

Co-authored-by: EmlynK <emlyn.kinzett@codeenigma.com>

* We probably don't need /bin/bash

* Making test.sh executable.

* Checking shell.

* Explicitly setting shell to bash in provision.sh.

* Trying ubuntu-16.04 as Travis used this.

* Putting shell back.

* Update provision.sh

* Making /bin/bash the shell.

* Making /bin/bash the shell for provision.

* Explicitly stating bash again in YML.

* Turns out the mkcert binary is out of date.

* Compiled mkcert from source.

* Fixing curl error.

* Switching to wget.

* Starting the linter again and renaming job.

* Only lint changed files.

* Linting a non-existent branch!

* Tidying the documentation check.

* Revert "Making /bin/bash the shell for provision."

This reverts commit f5f35818205cd364a66a6e51c9f9d8254f016422.

* Revert "Making /bin/bash the shell."

This reverts commit df585b36877aa2328adc228cd8f76950e2853d36.

* Revert "Tidying the documentation check."

This reverts commit a0c964e15003c8486f4d01232af6e855a475298e.

* Swapping Super-Linter for ansible-lint.

* Running ansible-lint directly in the container.

* Updating to latest Ubuntu.

* Revert "Fixing test.sh to explicitly call bash."

This reverts commit 521279ebc16a4c4459c981bfb813cf6aa4d4f3ad.

* Fixing ansible-lint issues.

* Revert "Fixing ansible-lint issues."

This reverts commit 08a74046d567ea80acc080ec3cec60a7f8ceed48.

* Removing old travis config.

* Spacing issue fix.

* Running tests on pull_request only.

Co-authored-by: EmlynK <emlyn.kinzett@codeenigma.com>

* Cleaning variables to be generic and improving LDAP role handling.

* Adding modified iam_alis module found on GitHub.

* Adding management of IAM account alias.

* Revert "Merge branch 'devel' into generate_saml_sso_requirements"

This reverts commit a4051979f45aa2518db36fd2f9c9751b0364b69c, reversing
changes made to b9e67325e2b69b9dd22483acaaec77ef80fa7177.

* Adding note on existence of 'config' directory for de-deploy to work.

* Adding link to provided example config directory.

Co-authored-by: EmlynK <emlyn.kinzett@codeenigma.com>

* phpfpm variables (#38)

* Use correct variable when setting the RDS instance type as part of ASG creation. (#27)

* GitHub actions into v1. (#30)

* Adding Super Linter workflow for GitHub Actions.

* Adding the documentation checker.

* Getting GitHub Actions to continue on failure.

* Seeing if Git exists.

* Missing space.

* Re-adding the checkout and the git commands.

* Trying Pascal's script.

* Adding both lines to the same 'run' command.

* GitHub Actions wtf - splitting into two steps.

* Trying steps on branch name.

* Trying steps on branch name AGAIN.

* Would be good to get the syntax right.

* Trying different quotes.

* Checking the contents of the github.ref variable.

* Trying to add in Pascal's testing step.

* Adding in /bin/sh to hopefully make test.sh run.

* Google says try it with /bin/bash.

* Trying a different Ubuntu version.

* Installing net-tools to have ifconfig.

* Updating testing shell (#28)

* Use correct variable when setting the RDS instance type as part of ASG creation. (#27)

* Fixing test.sh to explicitly call bash.

GitHub Actions only supports Ubuntu containers and Ubuntu shell is dash by default, not bash. Consequently /bin/sh doesn't invoke bash, but dash, which causes some unexpected errors down the line.

Co-authored-by: EmlynK <emlyn.kinzett@codeenigma.com>

* We probably don't need /bin/bash

* Making test.sh executable.

* Checking shell.

* Explicitly setting shell to bash in provision.sh.

* Trying ubuntu-16.04 as Travis used this.

* Putting shell back.

* Update provision.sh

* Making /bin/bash the shell.

* Making /bin/bash the shell for provision.

* Explicitly stating bash again in YML.

* Turns out the mkcert binary is out of date.

* Compiled mkcert from source.

* Fixing curl error.

* Switching to wget.

* Starting the linter again and renaming job.

* Only lint changed files.

* Linting a non-existent branch!

* Tidying the documentation check.

* Revert "Making /bin/bash the shell for provision."

This reverts commit f5f35818205cd364a66a6e51c9f9d8254f016422.

* Revert "Making /bin/bash the shell."

This reverts commit df585b36877aa2328adc228cd8f76950e2853d36.

* Revert "Tidying the documentation check."

This reverts commit a0c964e15003c8486f4d01232af6e855a475298e.

* Swapping Super-Linter for ansible-lint.

* Running ansible-lint directly in the container.

* Updating to latest Ubuntu.

* Revert "Fixing test.sh to explicitly call bash."

This reverts commit 521279ebc16a4c4459c981bfb813cf6aa4d4f3ad.

* Fixing ansible-lint issues.

* Revert "Fixing ansible-lint issues."

This reverts commit 08a74046d567ea80acc080ec3cec60a7f8ceed48.

* Removing old travis config.

* Spacing issue fix.

* Running tests on pull_request only.

Co-authored-by: EmlynK <emlyn.kinzett@codeenigma.com>

* Adding some PHP pool values that can be tweaked and the default_socket_timeout in php.ini.

Co-authored-by: Greg Harvey <greg.harvey@gmail.com>

* Generate saml sso requirements devel (#39)

* Use correct variable when setting the RDS instance type as part of ASG creation. (#27)

* Adding AWS CLI and credentials files to local ce-dev.

* New AWS IAM Ansible role for creating the necessary IdP and role for admin access.

* GitHub actions into v1. (#30)

* Adding Super Linter workflow for GitHub Actions.

* Adding the documentation checker.

* Getting GitHub Actions to continue on failure.

* Seeing if Git exists.

* Missing space.

* Re-adding the checkout and the git commands.

* Trying Pascal's script.

* Adding both lines to the same 'run' command.

* GitHub Actions wtf - splitting into two steps.

* Trying steps on branch name.

* Trying steps on branch name AGAIN.

* Would be good to get the syntax right.

* Trying different quotes.

* Checking the contents of the github.ref variable.

* Trying to add in Pascal's testing step.

* Adding in /bin/sh to hopefully make test.sh run.

* Google says try it with /bin/bash.

* Trying a different Ubuntu version.

* Installing net-tools to have ifconfig.

* Updating testing shell (#28)

* Use correct variable when setting the RDS instance type as part of ASG creation. (#27)

* Fixing test.sh to explicitly call bash.

GitHub Actions only supports Ubuntu containers and Ubuntu shell is dash by default, not bash. Consequently /bin/sh doesn't invoke bash, but dash, which causes some unexpected errors down the line.

Co-authored-by: EmlynK <emlyn.kinzett@codeenigma.com>

* We probably don't need /bin/bash

* Making test.sh executable.

* Checking shell.

* Explicitly setting shell to bash in provision.sh.

* Trying ubuntu-16.04 as Travis used this.

* Putting shell back.

* Update provision.sh

* Making /bin/bash the shell.

* Making /bin/bash the shell for provision.

* Explicitly stating bash again in YML.

* Turns out the mkcert binary is out of date.

* Compiled mkcert from source.

* Fixing curl error.

* Switching to wget.

* Starting the linter again and renaming job.

* Only lint changed files.

* Linting a non-existent branch!

* Tidying the documentation check.

* Revert "Making /bin/bash the shell for provision."

This reverts commit f5f35818205cd364a66a6e51c9f9d8254f016422.

* Revert "Making /bin/bash the shell."

This reverts commit df585b36877aa2328adc228cd8f76950e2853d36.

* Revert "Tidying the documentation check."

This reverts commit a0c964e15003c8486f4d01232af6e855a475298e.

* Swapping Super-Linter for ansible-lint.

* Running ansible-lint directly in the container.

* Updating to latest Ubuntu.

* Revert "Fixing test.sh to explicitly call bash."

This reverts commit 521279ebc16a4c4459c981bfb813cf6aa4d4f3ad.

* Fixing ansible-lint issues.

* Revert "Fixing ansible-lint issues."

This reverts commit 08a74046d567ea80acc080ec3cec60a7f8ceed48.

* Removing old travis config.

* Spacing issue fix.

* Running tests on pull_request only.

Co-authored-by: EmlynK <emlyn.kinzett@codeenigma.com>

* Cleaning variables to be generic and improving LDAP role handling.

* Adding modified iam_alis module found on GitHub.

* Adding management of IAM account alias.

* Revert "Merge branch 'devel' into generate_saml_sso_requirements"

This reverts commit a4051979f45aa2518db36fd2f9c9751b0364b69c, reversing
changes made to b9e67325e2b69b9dd22483acaaec77ef80fa7177.

* Fixing conflict with ce-dev/README.md.

* Adding a template for SimpleSAMLphp account SPs.

* Renaming template file for SAML and adding an include file for SAML admins.

* Renaming template file for SAML admins.

* Adding tasks for handling SimpleSAMLphp repo actions.

* Refactoring git commits to defend against existing files causing commit fails.

* Moving X509Certificate to a variable.

Co-authored-by: EmlynK <emlyn.kinzett@codeenigma.com>

* Override fastcgi_read_timeout in Nginx (#41)

* Use correct variable when setting the RDS instance type as part of ASG creation. (#27)

* GitHub actions into v1. (#30)

* Adding Super Linter workflow for GitHub Actions.

* Adding the documentation checker.

* Getting GitHub Actions to continue on failure.

* Seeing if Git exists.

* Missing space.

* Re-adding the checkout and the git commands.

* Trying Pascal's script.

* Adding both lines to the same 'run' command.

* GitHub Actions wtf - splitting into two steps.

* Trying steps on branch name.

* Trying steps on branch name AGAIN.

* Would be good to get the syntax right.

* Trying different quotes.

* Checking the contents of the github.ref variable.

* Trying to add in Pascal's testing step.

* Adding in /bin/sh to hopefully make test.sh run.

* Google says try it with /bin/bash.

* Trying a different Ubuntu version.

* Installing net-tools to have ifconfig.

* Updating testing shell (#28)

* Use correct variable when setting the RDS instance type as part of ASG creation. (#27)

* Fixing test.sh to explicitly call bash.

GitHub Actions only supports Ubuntu containers and Ubuntu shell is dash by default, not bash. Consequently /bin/sh doesn't invoke bash, but dash, which causes some unexpected errors down the line.

Co-authored-by: EmlynK <emlyn.kinzett@codeenigma.com>

* We probably don't need /bin/bash

* Making test.sh executable.

* Checking shell.

* Explicitly setting shell to bash in provision.sh.

* Trying ubuntu-16.04 as Travis used this.

* Putting shell back.

* Update provision.sh

* Making /bin/bash the shell.

* Making /bin/bash the shell for provision.

* Explicitly stating bash again in YML.

* Turns out the mkcert binary is out of date.

* Compiled mkcert from source.

* Fixing curl error.

* Switching to wget.

* Starting the linter again and renaming job.

* Only lint changed files.

* Linting a non-existent branch!

* Tidying the documentation check.

* Revert "Making /bin/bash the shell for provision."

This reverts commit f5f35818205cd364a66a6e51c9f9d8254f016422.

* Revert "Making /bin/bash the shell."

This reverts commit df585b36877aa2328adc228cd8f76950e2853d36.

* Revert "Tidying the documentation check."

This reverts commit a0c964e15003c8486f4d01232af6e855a475298e.

* Swapping Super-Linter for ansible-lint.

* Running ansible-lint directly in the container.

* Updating to latest Ubuntu.

* Revert "Fixing test.sh to explicitly call bash."

This reverts commit 521279ebc16a4c4459c981bfb813cf6aa4d4f3ad.

* Fixing ansible-lint issues.

* Revert "Fixing ansible-lint issues."

This reverts commit 08a74046d567ea80acc080ec3cec60a7f8ceed48.

* Removing old travis config.

* Spacing issue fix.

* Running tests on pull_request only.

Co-authored-by: EmlynK <emlyn.kinzett@codeenigma.com>

* Adding some PHP pool values that can be tweaked and the default_socket_timeout in php.ini. (#40)

* Add ability to override Nginx fastcgi_read_timeout value.

Co-authored-by: Greg Harvey <greg.harvey@gmail.com>

* Generate saml sso requirements devel (#42)

* Use correct variable when setting the RDS instance type as part of ASG creation. (#27)

* Adding AWS CLI and credentials files to local ce-dev.

* New AWS IAM Ansible role for creating the necessary IdP and role for admin access.

* GitHub actions into v1. (#30)

* Adding Super Linter workflow for GitHub Actions.

* Adding the documentation checker.

* Getting GitHub Actions to continue on failure.

* Seeing if Git exists.

* Missing space.

* Re-adding the checkout and the git commands.

* Trying Pascal's script.

* Adding both lines to the same 'run' command.

* GitHub Actions wtf - splitting into two steps.

* Trying steps on branch name.

* Trying steps on branch name AGAIN.

* Would be good to get the syntax right.

* Trying different quotes.

* Checking the contents of the github.ref variable.

* Trying to add in Pascal's testing step.

* Adding in /bin/sh to hopefully make test.sh run.

* Google says try it with /bin/bash.

* Trying a different Ubuntu version.

* Installing net-tools to have ifconfig.

* Updating testing shell (#28)

* Use correct variable when setting the RDS instance type as part of ASG creation. (#27)

* Fixing test.sh to explicitly call bash.

GitHub Actions only supports Ubuntu containers and Ubuntu shell is dash by default, not bash. Consequently /bin/sh doesn't invoke bash, but dash, which causes some unexpected errors down the line.

Co-authored-by: EmlynK <emlyn.kinzett@codeenigma.com>

* We probably don't need /bin/bash

* Making test.sh executable.

* Checking shell.

* Explicitly setting shell to bash in provision.sh.

* Trying ubuntu-16.04 as Travis used this.

* Putting shell back.

* Update provision.sh

* Making /bin/bash the shell.

* Making /bin/bash the shell for provision.

* Explicitly stating bash again in YML.

* Turns out the mkcert binary is out of date.

* Compiled mkcert from source.

* Fixing curl error.

* Switching to wget.

* Starting the linter again and renaming job.

* Only lint changed files.

* Linting a non-existent branch!

* Tidying the documentation check.

* Revert "Making /bin/bash the shell for provision."

This reverts commit f5f35818205cd364a66a6e51c9f9d8254f016422.

* Revert "Making /bin/bash the shell."

This reverts commit df585b36877aa2328adc228cd8f76950e2853d36.

* Revert "Tidying the documentation check."

This reverts commit a0c964e15003c8486f4d01232af6e855a475298e.

* Swapping Super-Linter for ansible-lint.

* Running ansible-lint directly in the container.

* Updating to latest Ubuntu.

* Revert "Fixing test.sh to explicitly call bash."

This reverts commit 521279ebc16a4c4459c981bfb813cf6aa4d4f3ad.

* Fixing ansible-lint issues.

* Revert "Fixing ansible-lint issues."

This reverts commit 08a74046d567ea80acc080ec3cec60a7f8ceed48.

* Removing old travis config.

* Spacing issue fix.

* Running tests on pull_request only.

Co-authored-by: EmlynK <emlyn.kinzett@codeenigma.com>

* Cleaning variables to be generic and improving LDAP role handling.

* Adding modified iam_alis module found on GitHub.

* Adding management of IAM account alias.

* Revert "Merge branch 'devel' into generate_saml_sso_requirements"

This reverts commit a4051979f45aa2518db36fd2f9c9751b0364b69c, reversing
changes made to b9e67325e2b69b9dd22483acaaec77ef80fa7177.

* Fixing conflict with ce-dev/README.md.

* Adding a template for SimpleSAMLphp account SPs.

* Renaming template file for SAML and adding an include file for SAML admins.

* Renaming template file for SAML admins.

* Adding tasks for handling SimpleSAMLphp repo actions.

* Refactoring git commits to defend against existing files causing commit fails.

* Moving X509Certificate to a variable.

* Wrapping the LinOTP code in the SAML template in an 'if' statement.

Co-authored-by: EmlynK <emlyn.kinzett@codeenigma.com>

* Generate saml sso requirements devel (#43)

* Use correct variable when setting the RDS instance type as part of ASG creation. (#27)

* Adding AWS CLI and credentials files to local ce-dev.

* New AWS IAM Ansible role for creating the necessary IdP and role for admin access.

* GitHub actions into v1. (#30)

* Adding Super Linter workflow for GitHub Actions.

* Adding the documentation checker.

* Getting GitHub Actions to continue on failure.

* Seeing if Git exists.

* Missing space.

* Re-adding the checkout and the git commands.

* Trying Pascal's script.

* Adding both lines to the same 'run' command.

* GitHub Actions wtf - splitting into two steps.

* Trying steps on branch name.

* Trying steps on branch name AGAIN.

* Would be good to get the syntax right.

* Trying different quotes.

* Checking the contents of the github.ref variable.

* Trying to add in Pascal's testing step.

* Adding in /bin/sh to hopefully make test.sh run.

* Google says try it with /bin/bash.

* Trying a different Ubuntu version.

* Installing net-tools to have ifconfig.

* Updating testing shell (#28)

* Use correct variable when setting the RDS instance type as part of ASG creation. (#27)

* Fixing test.sh to explicitly call bash.

GitHub Actions only supports Ubuntu containers and Ubuntu shell is dash by default, not bash. Consequently /bin/sh doesn't invoke bash, but dash, which causes some unexpected errors down the line.

Co-authored-by: EmlynK <emlyn.kinzett@codeenigma.com>

* We probably don't need /bin/bash

* Making test.sh executable.

* Checking shell.

* Explicitly setting shell to bash in provision.sh.

* Trying ubuntu-16.04 as Travis used this.

* Putting shell back.

* Update provision.sh

* Making /bin/bash the shell.

* Making /bin/bash the shell for provision.

* Explicitly stating bash again in YML.

* Turns out the mkcert binary is out of date.

* Compiled mkcert from source.

* Fixing curl error.

* Switching to wget.

* Starting the linter again and renaming job.

* Only lint changed files.

* Linting a non-existent branch!

* Tidying the documentation check.

* Revert "Making /bin/bash the shell for provision."

This reverts commit f5f35818205cd364a66a6e51c9f9d8254f016422.

* Revert "Making /bin/bash the shell."

This reverts commit df585b36877aa2328adc228cd8f76950e2853d36.

* Revert "Tidying the documentation check."

This reverts commit a0c964e15003c8486f4d01232af6e855a475298e.

* Swapping Super-Linter for ansible-lint.

* Running ansible-lint directly in the container.

* Updating to latest Ubuntu.

* Revert "Fixing test.sh to explicitly call bash."

This reverts commit 521279ebc16a4c4459c981bfb813cf6aa4d4f3ad.

* Fixing ansible-lint issues.

* Revert "Fixing ansible-lint issues."

This reverts commit 08a74046d567ea80acc080ec3cec60a7f8ceed48.

* Removing old travis config.

* Spacing issue fix.

* Running tests on pull_request only.

Co-authored-by: EmlynK <emlyn.kinzett@codeenigma.com>

* Cleaning variables to be generic and improving LDAP role handling.

* Adding modified iam_alis module found on GitHub.

* Adding management of IAM account alias.

* Revert "Merge branch 'devel' into generate_saml_sso_requirements"

This reverts commit a4051979f45aa2518db36fd2f9c9751b0364b69c, reversing
changes made to b9e67325e2b69b9dd22483acaaec77ef80fa7177.

* Fixing conflict with ce-dev/README.md.

* Adding a template for SimpleSAMLphp account SPs.

* Renaming template file for SAML and adding an include file for SAML admins.

* Renaming template file for SAML admins.

* Adding tasks for handling SimpleSAMLphp repo actions.

* Refactoring git commits to defend against existing files causing commit fails.

* Moving X509Certificate to a variable.

* Wrapping the LinOTP code in the SAML template in an 'if' statement.

* Extending the check to make sure LinOTP var isn't empty.

* Removing references to LDAP in SAML groups attribute config, no need to assume.

* Adding docs for the aws_iam_saml role.

Co-authored-by: EmlynK <emlyn.kinzett@codeenigma.com>

* Adding aws_iam_saml docs (#45)

* Use correct variable when setting the RDS instance type as part of ASG creation. (#27)

* GitHub actions into v1. (#30)

* Adding Super Linter workflow for GitHub Actions.

* Adding the documentation checker.

* Getting GitHub Actions to continue on failure.

* Seeing if Git exists.

* Missing space.

* Re-adding the checkout and the git commands.

* Trying Pascal's script.

* Adding both lines to the same 'run' command.

* GitHub Actions wtf - splitting into two steps.

* Trying steps on branch name.

* Trying steps on branch name AGAIN.

* Would be good to get the syntax right.

* Trying different quotes.

* Checking the contents of the github.ref variable.

* Trying to add in Pascal's testing step.

* Adding in /bin/sh to hopefully make test.sh run.

* Google says try it with /bin/bash.

* Trying a different Ubuntu version.

* Installing net-tools to have ifconfig.

* Updating testing shell (#28)

* Use correct variable when setting the RDS instance type as part of ASG creation. (#27)

* Fixing test.sh to explicitly call bash.

GitHub Actions only supports Ubuntu containers and Ubuntu shell is dash by default, not bash. Consequently /bin/sh doesn't invoke bash, but dash, which causes some unexpected errors down the line.

Co-authored-by: EmlynK <emlyn.kinzett@codeenigma.com>

* We probably don't need /bin/bash

* Making test.sh executable.

* Checking shell.

* Explicitly setting shell to bash in provision.sh.

* Trying ubuntu-16.04 as Travis used this.

* Putting shell back.

* Update provision.sh

* Making /bin/bash the shell.

* Making /bin/bash the shell for provision.

* Explicitly stating bash again in YML.

* Turns out the mkcert binary is out of date.

* Compiled mkcert from source.

* Fixing curl error.

* Switching to wget.

* Starting the linter again and renaming job.

* Only lint changed files.

* Linting a non-existent branch!

* Tidying the documentation check.

* Revert "Making /bin/bash the shell for provision."

This reverts commit f5f35818205cd364a66a6e51c9f9d8254f016422.

* Revert "Making /bin/bash the shell."

This reverts commit df585b36877aa2328adc228cd8f76950e2853d36.

* Revert "Tidying the documentation check."

This reverts commit a0c964e15003c8486f4d01232af6e855a475298e.

* Swapping Super-Linter for ansible-lint.

* Running ansible-lint directly in the container.

* Updating to latest Ubuntu.

* Revert "Fixing test.sh to explicitly call bash."

This reverts commit 521279ebc16a4c4459c981bfb813cf6aa4d4f3ad.

* Fixing ansible-lint issues.

* Revert "Fixing ansible-lint issues."

This reverts commit 08a74046d567ea80acc080ec3cec60a7f8ceed48.

* Removing old travis config.

* Spacing issue fix.

* Running tests on pull_request only.

Co-authored-by: EmlynK <emlyn.kinzett@codeenigma.com>

* Adding some PHP pool values that can be tweaked and the default_socket_timeout in php.ini. (#40)

* Generate saml sso requirements 1x (#44)

* Wrong filter for efs info

* Fix indentation error

* Do not purge tags on existing EFS

* Wrong name for updating EFS targets

* Remove leftover loop

* Fix error in subnet gathering

* Split EFS creation

* Use subnet ids

* Wrong var name

* Remove dead code

* Wrong var

* Missing subnet ids

* Try not to loose existing SGs

* Try to dedupe targets

* Wrong syntax for combine

* Typo in combining tupples

* Wrong var name for append items

* Fix appending subnets

* Wrong list transformation

* Switch to community module for efs

* Remove unecessary complexity

* Update documentation

* Comment out Redefine Autoscale groups task for now and move some of its parameters to the other ASG creation task.

* Remove replace_batch_size from ASG creation task, so it now defaults to 1.

* Wrap Postfix handler commands in quotes. (#26)

* Try using shell instead of command in Postfix handlers.

* GitHub Actions integration (#29)

* Adding Super Linter workflow for GitHub Actions.

* Adding the documentation checker.

* Getting GitHub Actions to continue on failure.

* Seeing if Git exists.

* Missing space.

* Re-adding the checkout and the git commands.

* Trying Pascal's script.

* Adding both lines to the same 'run' command.

* GitHub Actions wtf - splitting into two steps.

* Trying steps on branch name.

* Trying steps on branch name AGAIN.

* Would be good to get the syntax right.

* Trying different quotes.

* Checking the contents of the github.ref variable.

* Trying to add in Pascal's testing step.

* Adding in /bin/sh to hopefully make test.sh run.

* Google says try it with /bin/bash.

* Trying a different Ubuntu version.

* Installing net-tools to have ifconfig.

* Updating testing shell (#28)

* Use correct variable when setting the RDS instance type as part of ASG creation. (#27)

* Fixing test.sh to explicitly call bash.

GitHub Actions only supports Ubuntu containers and Ubuntu shell is dash by default, not bash. Consequently /bin/sh doesn't invoke bash, but dash, which causes some unexpected errors down the line.

Co-authored-by: EmlynK <emlyn.kinzett@codeenigma.com>

* We probably don't need /bin/bash

* Making test.sh executable.

* Checking shell.

* Explicitly setting shell to bash in provision.sh.

* Trying ubuntu-16.04 as Travis used this.

* Putting shell back.

* Update provision.sh

* Making /bin/bash the shell.

* Making /bin/bash the shell for provision.

* Explicitly stating bash again in YML.

* Turns out the mkcert binary is out of date.

* Compiled mkcert from source.

* Fixing curl error.

* Switching to wget.

* Starting the linter again and renaming job.

* Only lint changed files.

* Linting a non-existent branch!

* Tidying the documentation check.

* Revert "Making /bin/bash the shell for provision."

This reverts commit f5f35818205cd364a66a6e51c9f9d8254f016422.

* Revert "Making /bin/bash the shell."

This reverts commit df585b36877aa2328adc228cd8f76950e2853d36.

* Revert "Tidying the documentation check."

This reverts commit a0c964e15003c8486f4d01232af6e855a475298e.

* Swapping Super-Linter for ansible-lint.

* Running ansible-lint directly in the container.

* Updating to latest Ubuntu.

* Revert "Fixing test.sh to explicitly call bash."

This reverts commit 521279ebc16a4c4459c981bfb813cf6aa4d4f3ad.

* Fixing ansible-lint issues.

* Revert "Fixing ansible-lint issues."

This reverts commit 08a74046d567ea80acc080ec3cec60a7f8ceed48.

* Removing old travis config.

* Spacing issue fix.

* Running tests on pull_request only.

Co-authored-by: EmlynK <emlyn.kinzett@codeenigma.com>

* Use correct variable when setting the RDS instance type as part of ASG creation. (#32)

Co-authored-by: Emlyn Kinzett <emlyn.kinzett@codeenigma.com>

* Fix alb health check (#31)

* It's traffic-port, not target-port. Doh.

* Update documentation.

Co-authored-by: Emlyn Kinzett <emlyn.kinzett@codeenigma.com>

* Adding note on existence of 'config' directory for de-deploy to work.

* Adding link to provided example config directory.

* Adding AWS CLI and credentials files to local ce-dev.

* New AWS IAM Ansible role for creating the necessary IdP and role for admin access.

* Generate saml sso requirements (#33)

* Use correct variable when setting the RDS instance type as part of ASG creation. (#27)

* Adding AWS CLI and credentials files to local ce-dev.

* New AWS IAM Ansible role for creating the necessary IdP and role for admin access.

Co-authored-by: EmlynK <emlyn.kinzett@codeenigma.com>

* Cleaning variables to be generic and improving LDAP role handling.

* Adding modified iam_alis module found on GitHub.

* Generate saml sso requirements devel (#36)

* Use correct variable when setting the RDS instance type as part of ASG creation. (#27)

* Adding AWS CLI and credentials files to local ce-dev.

* New AWS IAM Ansible role for creating the necessary IdP and role for admin access.

* Cleaning variables to be generic and improving LDAP role handling.

Co-authored-by: EmlynK <emlyn.kinzett@codeenigma.com>

* Adding management of IAM account alias.

* Revert "Merge branch 'devel' into generate_saml_sso_requirements"

This reverts commit a4051979f45aa2518db36fd2f9c9751b0364b69c, reversing
changes made to b9e67325e2b69b9dd22483acaaec77ef80fa7177.

* Generate saml sso requirements devel (#37)

* Use correct variable when setting the RDS instance type as part of ASG creation. (#27)

* Adding AWS CLI and credentials files to local ce-dev.

* New AWS IAM Ansible role for creating the necessary IdP and role for admin access.

* GitHub actions into v1. (#30)

* Adding Super Linter workflow for GitHub Actions.

* Adding the documentation checker.

* Getting GitHub Actions to continue on failure.

* Seeing if Git exists.

* Missing space.

* Re-adding the checkout and the git commands.

* Trying Pascal's script.

* Adding both lines to the same 'run' command.

* GitHub Actions wtf - splitting into two steps.

* Trying steps on branch name.

* Trying steps on branch name AGAIN.

* Would be good to get the syntax right.

* Trying different quotes.

* Checking the contents of the github.ref variable.

* Trying to add in Pascal's testing step.

* Adding in /bin/sh to hopefully make test.sh run.

* Google says try it with /bin/bash.

* Trying a different Ubuntu version.

* Installing net-tools to have ifconfig.

* Updating testing shell (#28)

* Use correct variable when setting the RDS instance type as part of ASG creation. (#27)

* Fixing test.sh to explicitly call bash.

GitHub Actions only supports Ubuntu containers and Ubuntu shell is dash by default, not bash. Consequently /bin/sh doesn't invoke bash, but dash, which causes some unexpected errors down the line.

Co-authored-by: EmlynK <emlyn.kinzett@codeenigma.com>

* We probably don't need /bin/bash

* Making test.sh executable.

* Checking shell.

* Explicitly setting shell to bash in provision.sh.

* Trying ubuntu-16.04 as Travis used this.

* Putting shell back.

* Update provision.sh

* Making /bin/bash the shell.

* Making /bin/bash the shell for provision.

* Explicitly stating bash again in YML.

* Turns out the mkcert binary is out of date.

* Compiled mkcert from source.

* Fixing curl error.

* Switching to wget.

* Starting the linter again and renaming job.

* Only lint changed files.

* Linting a non-existent branch!

* Tidying the documentation check.

* Revert "Making /bin/bash the shell for provision."

This reverts commit f5f35818205cd364a66a6e51c9f9d8254f016422.

* Revert "Making /bin/bash the shell."

This reverts commit df585b36877aa2328adc228cd8f76950e2853d36.

* Revert "Tidying the documentation check."

This reverts commit a0c964e15003c8486f4d01232af6e855a475298e.

* Swapping Super-Linter for ansible-lint.

* Running ansible-lint directly in the container.

* Updating to latest Ubuntu.

* Revert "Fixing test.sh to explicitly call bash."

This reverts commit 521279ebc16a4c4459c981bfb813cf6aa4d4f3ad.

* Fixing ansible-lint issues.

* Revert "Fixing ansible-lint issues."

This reverts commit 08a74046d567ea80acc080ec3cec60a7f8ceed48.

* Removing old travis config.

* Spacing issue fix.

* Running tests on pull_request only.

Co-authored-by: EmlynK <emlyn.kinzett@codeenigma.com>

* Cleaning variables to be generic and improving LDAP role handling.

* Adding modified iam_alis module found on GitHub.

* Adding management of IAM account alias.

* Revert "Merge branch 'devel' into generate_saml_sso_requirements"

This reverts commit a4051979f45aa2518db36fd2f9c9751b0364b69c, reversing
changes made to b9e67325e2b69b9dd22483acaaec77ef80fa7177.

* Adding note on existence of 'config' directory for de-deploy to work.

* Adding link to provided example config directory.

Co-authored-by: EmlynK <emlyn.kinzett@codeenigma.com>

* Fixing conflict with ce-dev/README.md.

* Adding a template for SimpleSAMLphp account SPs.

* Renaming template file for SAML and adding an include file for SAML admins.

* Renaming template file for SAML admins.

* phpfpm variables (#38)

* Use correct variable when setting the RDS instance type as part of ASG creation. (#27)

* GitHub actions into v1. (#30)

* Adding Super Linter workflow for GitHub Actions.

* Adding the documentation checker.

* Getting GitHub Actions to continue on failure.

* Seeing if Git exists.

* Missing space.

* Re-adding the checkout and the git commands.

* Trying Pascal's script.

* Adding both lines to the same 'run' command.

* GitHub Actions wtf - splitting into two steps.

* Trying steps on branch name.

* Trying steps on branch name AGAIN.

* Would be good to get the syntax right.

* Trying different quotes.

* Checking the contents of the github.ref variable.

* Trying to add in Pascal's testing step.

* Adding in /bin/sh to hopefully make test.sh run.

* Google says try it with /bin/bash.

* Trying a different Ubuntu version.

* Installing net-tools to have ifconfig.

* Updating testing shell (#28)

* Use correct variable when setting the RDS instance type as part of ASG creation. (#27)

* Fixing test.sh to explicitly call bash.

GitHub Actions only supports Ubuntu containers and Ubuntu shell is dash by default, not bash. Consequently /bin/sh doesn't invoke bash, but dash, which causes some unexpected errors down the line.

Co-authored-by: EmlynK <emlyn.kinzett@codeenigma.com>

* We probably don't need /bin/bash

* Making test.sh executable.

* Checking shell.

* Explicitly setting shell to bash in provision.sh.

* Trying ubuntu-16.04 as Travis used this.

* Putting shell back.

* Update provision.sh

* Making /bin/bash the shell.

* Making /bin/bash the shell for provision.

* Explicitly stating bash again in YML.

* Turns out the mkcert binary is out of date.

* Compiled mkcert from source.

* Fixing curl error.

* Switching to wget.

* Starting the linter again and renaming job.

* Only lint changed files.

* Linting a non-existent branch!

* Tidying the documentation check.

* Revert "Making /bin/bash the shell for provision."

This reverts commit f5f35818205cd364a66a6e51c9f9d8254f016422.

* Revert "Making /bin/bash the shell."

This reverts commit df585b36877aa2328adc228cd8f76950e2853d36.

* Revert "Tidying the documentation check."

This reverts commit a0c964e15003c8486f4d01232af6e855a475298e.

* Swapping Super-Linter for ansible-lint.

* Running ansible-lint directly in the container.

* Updating to latest Ubuntu.

* Revert "Fixing test.sh to explicitly call bash."

This reverts commit 521279ebc16a4c4459c981bfb813cf6aa4d4f3ad.

* Fixing ansible-lint issues.

* Revert "Fixing ansible-lint issues."

This reverts commit 08a74046d567ea80acc080ec3cec60a7f8ceed48.

* Removing old travis config.

* Spacing issue fix.

* Running tests on pull_request only.

Co-authored-by: EmlynK <emlyn.kinzett@codeenigma.com>

* Adding some PHP pool values that can be tweaked and the default_socket_timeout in php.ini.

Co-authored-by: Greg Harvey <greg.harvey@gmail.com>

* Adding tasks for handling SimpleSAMLphp repo actions.

* Refactoring git commits to defend against existing files causing commit fails.

* Moving X509Certificate to a variable.

* Generate saml sso requirements devel (#39)

* Use correct variable when setting the RDS instance type as part of ASG creation. (#27)

* Adding AWS CLI and credentials files to local ce-dev.

* New AWS IAM Ansible role for creating the necessary IdP and role for admin access.

* GitHub actions into v1. (#30)

* Adding Super Linter workflow for GitHub Actions.

* Adding the documentation checker.

* Getting GitHub Actions to continue on failure.

* Seeing if Git exists.

* Missing space.

* Re-adding the checkout and the git commands.

* Trying Pascal's script.

* Adding both lines to the same 'run' command.

* GitHub Actions wtf - splitting into two steps.

* Trying steps on branch name.

* Trying steps on branch name AGAIN.

* Would be good to get the syntax right.

* Trying different quotes.

* Checking the contents of the github.ref variable.

* Trying to add in Pascal's testing step.

* Adding in /bin/sh to hopefully make test.sh run.

* Google says try it with /bin/bash.

* Trying a different Ubuntu version.

* Installing net-tools to have ifconfig.

* Updating testing shell (#28)

* Use correct variable when setting the RDS instance type as part of ASG creation. (#27)

* Fixing test.sh to explicitly call bash.

GitHub Actions only supports Ubuntu containers and Ubuntu shell is dash by default, not bash. Consequently /bin/sh doesn't invoke bash, but dash, which causes some unexpected errors down the line.

Co-authored-by: EmlynK <emlyn.kinzett@codeenigma.com>

* We probably don't need /bin/bash

* Making test.sh executable.

* Checking shell.

* Explicitly setting shell to bash in provision.sh.

* Trying ubuntu-16.04 as Travis used this.

* Putting shell back.

* Update provision.sh

* Making /bin/bash the shell.

* Making /bin/bash the shell for provision.

* Explicitly stating bash again in YML.

* Turns out the mkcert binary is out of date.

* Compiled mkcert from source.

* Fixing curl error.

* Switching to wget.

* Starting the linter again and renaming job.

* Only lint changed files.

* Linting a non-existent branch!

* Tidying the documentation check.

* Revert "Making /bin/bash the shell for provision."

This reverts commit f5f35818205cd364a66a6e51c9f9d8254f016422.

* Revert "Making /bin/bash the shell."

This reverts commit df585b36877aa2328adc228cd8f76950e2853d36.

* Revert "Tidying the documentation check."

This reverts commit a0c964e15003c8486f4d01232af6e855a475298e.

* Swapping Super-Linter for ansible-lint.

* Running ansible-lint directly in the container.

* Updating to latest Ubuntu.

* Revert "Fixing test.sh to explicitly call bash."

This reverts commit 521279ebc16a4c4459c981bfb813cf6aa4d4f3ad.

* Fixing ansible-lint issues.

* Revert "Fixing ansible-lint issues."

This reverts commit 08a74046d567ea80acc080ec3cec60a7f8ceed48.

* Removing old travis config.

* Spacing issue fix.

* Running tests on pull_request only.

Co-authored-by: EmlynK <emlyn.kinzett@codeenigma.com>

* Cleaning variables to be generic and improving LDAP role handling.

* Adding modified iam_alis module found on GitHub.

* Adding management of IAM account alias.

* Revert "Merge branch 'devel' into generate_saml_sso_requirements"

This reverts commit a4051979f45aa2518db36fd2f9c9751b0364b69c, reversing
changes made to b9e67325e2b69b9dd22483acaaec77ef80fa7177.

* Fixing conflict with ce-dev/README.md.

* Adding a template for SimpleSAMLphp account SPs.

* Renaming template f…