### PR TITLE
r62347 fix postfix email delivery

### DIFF
--- a/roles/postfix/defaults/main.yml
+++ b/roles/postfix/defaults/main.yml
@@ -8,10 +8,7 @@ postfix:
   # ce_dev_delivery_mode is only used when is_local == true, which means you're probably using ce-dev locally. Valid modes are host, local and discard.
   ce_dev_delivery_mode: "host"
   message_size: 10240000
-  networks:
-    - "[::1]/128"
-    - "[::ffff:127.0.0.0]/104"
-    - 127.0.0.0/8
+  networks: "[::1]/128 [::ffff:127.0.0.0]/104 127.0.0.0/8"
   protocols: all
   relayhost: ""
   transport_maps:

--- a/roles/postfix/tasks/main.yml
+++ b/roles/postfix/tasks/main.yml
@@ -131,6 +131,11 @@
   loop_control:
     loop_var: lock_file
 
+- name: Create Postfix Aliases database
+  ansible.builtin.command:
+    cmd: /usr/bin/newaliases
+    warn: false
+
 - name: Restart Postfix
   ansible.builtin.command:
     cmd: /usr/sbin/service postfix start


### PR DESCRIPTION
The change in format of 'networks' declaration should resolve this error observed in mail.err;
`postfix/smtpd[10732]: error: unsupported dictionary type: '[`

The execution of newaliases on postfix install should resolve this;
`postfix/smtpd[10459]: error: open database /etc/aliases.db: No such file or directory`

Test with dummy-monitor1;
1. Changes in ce-provision pushed to devel;
https://github.com/codeenigma/ce-provision/pull/791

2. dummy-monitor1 rebuilt;
https://gitlab.dummy-infra1.codeenigma.net/infras/dummy/infra-dummy/-/jobs/8719

3. Confirm changes effected in dummy-monitor1;
- mynetworks correctly formatted
```
# cat /etc/postfix/main.cf | grep "mynetworks ="
mynetworks = [::1]/128 [::ffff:127.0.0.0]/104 127.0.0.0/8
```
- aliases database created
```
# ls -al /etc | grep aliases
-rw-r--r--  1 root         root           198 Feb 11 10:15 aliases
-rw-r--r--  1 root         root         12288 Aug  3 09:47 aliases.db
```

Test passed, merge to 1.x