### PR TITLE
Temporarily pinning amazon.aws collection to version 4.0.0 - see http…

### DIFF
--- a/roles/ce_provision/meta/requirements.yml
+++ b/roles/ce_provision/meta/requirements.yml
@@ -3,6 +3,7 @@ collections:
   - name: community.aws
   - name: community.general
   - name: amazon.aws
+    version: 4.0.0
 
 roles:
   - name: geerlingguy.varnish


### PR DESCRIPTION
See https://github.com/ansible-collections/amazon.aws/issues/950

Upstream issue with latest `amazon.aws` collection is mysteriously breaking EC2 discovery.