### PR TITLE
R66519 r66187 fix postfix transport map db pr 1.x

### DIFF
--- a/roles/postfix/handlers/main.yml
+++ b/roles/postfix/handlers/main.yml
@@ -1,10 +1,4 @@
 ---
-- name: Initialise transport.
-  ansible.builtin.command: /usr/sbin/postmap /etc/postfix/transport
-
-- name: Initialise sasl_passwd.
-  ansible.builtin.command: /usr/sbin/postmap /etc/postfix/sasl_passwd
-
 - name: Initialise virtual.
   ansible.builtin.command: /usr/sbin/postmap /etc/postfix/virtual
 

--- a/roles/postfix/tasks/main.yml
+++ b/roles/postfix/tasks/main.yml
@@ -44,8 +44,11 @@
     group: root
     mode: "0644"
   notify:
-    - Initialise transport.
     - Reload Postfix configuration.
+
+- name: Initialise transport db
+  ansible.builtin.command:
+    cmd: /usr/sbin/postmap /etc/postfix/transport
 
 - name: Install SASL
   ansible.builtin.package:
@@ -62,8 +65,12 @@
     mode: "0644"
   when: postfix.use_ses
   notify:
-    - Initialise sasl_passwd.
     - Reload Postfix configuration.
+
+- name: Initialise sasl_passwd
+  ansible.builtin.command:
+    cmd: /usr/sbin/postmap /etc/postfix/sasl_passwd
+  when: postfix.use_ses
 
 - name: Configure virtual
   ansible.builtin.template:


### PR DESCRIPTION
move transport and sasl_passwd db generation from handler to task so they are executed every time, not only on change.