### PR TITLE
move ssl to domain.yml to fix the loop; remove checking for existing …

### DIFF
--- a/roles/debian/nginx/tasks/domain.yml
+++ b/roles/debian/nginx/tasks/domain.yml
@@ -1,4 +1,9 @@
 ---
+- name: Generate SSL certificates.
+  ansible.builtin.include_tasks: ssl.yml
+  when:
+    - domain.ssl is defined
+
 - name: Set up basic auth.
   when:
     - domain.basic_auth.auth_enabled is defined

--- a/roles/debian/nginx/tasks/main.yml
+++ b/roles/debian/nginx/tasks/main.yml
@@ -111,17 +111,6 @@
   when:
     - _nginx_cloudwatch_dir.stat.isdir is defined and _nginx_cloudwatch_dir.stat.isdir
 
-- name: Generate SSL certificates.
-  ansible.builtin.include_tasks: ssl.yml
-  with_items: "{{ nginx.domains }}"
-  loop_control:
-    loop_var: domain
-  when:
-    - domain.ssl is defined
-    - nginx.domains is defined
-    - nginx.domains | length > 0
-    - nginx.recreate_vhosts
-
 - name: Generate domain specific configuration.
   ansible.builtin.include_tasks: domain.yml
   with_items: "{{ nginx.domains }}"

--- a/roles/debian/nginx/tasks/ssl.yml
+++ b/roles/debian/nginx/tasks/ssl.yml
@@ -1,14 +1,8 @@
 ---
-# If there is an existing vhost it will have LE proxy handling already.
-- name: Check for an existing vhost.
-  ansible.builtin.stat:
-    path: "/etc/nginx/sites-enabled/{{ domain.server_name }}.conf"
-  register: _nginx_vhost_link
-
 - name: LetsEncrypt create vhosts.
   when:
     - domain.ssl.handling == 'letsencrypt'
-    - _nginx_vhost_link.stat.islnk is not defined or domain.ssl.services | length > 0 # if services[] is defined we can assume we are running certbot on port 80 or 443
+    - domain.ssl.services | length > 0 # if services[] is defined we can assume we are running certbot on port 80 or 443
   block:
     - name: Temporarily place a vhost for LetsEncrypt to work.
       ansible.builtin.template:
@@ -39,7 +33,7 @@
 - name: LetsEncrypt cleanup vhosts.
   when:
     - domain.ssl.handling == 'letsencrypt'
-    - _nginx_vhost_link.stat.islnk is not defined or domain.ssl.services | length > 0 # if services[] is defined we can assume we are running certbot on port 80 or 443
+    - domain.ssl.services | length > 0 # if services[] is defined we can assume we are running certbot on port 80 or 443
   block:
     - name: Delete the link to the vhost for LetsEncrypt.
       ansible.builtin.file:


### PR DESCRIPTION
…vhost as the LE proxy handling may not be there if SSL wasn not configured before, and the vhost will not be there as we are recreating them by default