### PR TITLE
fix(scripts): Fix git checkout to fetch any new branches

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -205,6 +205,8 @@ ansible_play(){
 # @param $1 absolute path to local repo.
 # @param $2 branch to checkout.
 git_checkout(){
+  # We need to fetch first for new branches.
+  git -C "$1" fetch origin "$2"
   git -C "$1" checkout "$2"
   git -C "$1" pull origin "$2"
 }


### PR DESCRIPTION
Problem: when I want to test any new branch in my ce-provision-confg directory then the provision.sh script fails because it cannot find the new branch locally.

Solution: fetch first from the remote before checking out, that way the branch is always there.