### PR TITLE
fix(redis): Convert maxmemory setting to int before comparing

### DIFF
--- a/roles/debian/redis/templates/redis.conf.j2
+++ b/roles/debian/redis/templates/redis.conf.j2
@@ -538,7 +538,7 @@ slave-priority 100
 # output buffers (but this is not needed if the policy is 'noeviction').
 #
 # maxmemory <bytes>
-{% if redis.maxmemory > 0 %}
+{% if (redis.maxmemory | int) > 0 %}
 maxmemory {{ redis.maxmemory }}
 {% endif %}
 # MAXMEMORY POLICY: how Redis will select what to remove when maxmemory


### PR DESCRIPTION
Problem: when building the maxmemory setting dynamically from total RAM for example, then it is returned as template string. It needs to be converted to string before comparing.