### PR TITLE
fix(debian/duplicity): Fix missing compilation dependencies

### DIFF
--- a/roles/debian/duplicity/tasks/main.yml
+++ b/roles/debian/duplicity/tasks/main.yml
@@ -16,6 +16,13 @@
     - pip3
   failed_when: false # don't stop the build if there's no system pip
 
+- name: Install compilation dependencies for duplicity.
+  ansible.builtin.apt:
+    pkg:
+      - gettext
+      - librsync-dev
+      - python3-dev
+
 # Optionally set Python venv variables.
 - name: Override Python venv path if provided.
   ansible.builtin.set_fact:


### PR DESCRIPTION
Problem: when running on a clean Debian 11 instance this fails because a couple of system dependencies are missing that are required when some duplicity dependencies are compiled.

We can install them with APT.

```
Building extension for librsync...
          building 'duplicity._librsync' extension
          creating build/temp.linux-x86_64-cpython-39/duplicity
          x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -ffile-prefix-map=/build/python3.9-RNBry6/python3.9-3.9.2=. -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -fPIC -I/usr/local/include -I/usr/include -I/home/jenkins/ce-python/include -I/usr/include/python3.9 -c duplicity/_librsyncmodule.c -o build/temp.linux-x86_64-cpython-39/duplicity/_librsyncmodule.o
          duplicity/_librsyncmodule.c:26:10: fatal error: Python.h: No such file or directory
             26 | #include <Python.h>
                |          ^~~~~~~~~~
          compilation terminated.
          error: command '/usr/bin/x86_64-linux-gnu-gcc' failed with exit code 1
          [end of output]
```